### PR TITLE
WIP: add freesurfer recon fields

### DIFF
--- a/datalad_ukbiobank/ukb2bids_map.py
+++ b/datalad_ukbiobank/ukb2bids_map.py
@@ -23,6 +23,7 @@ ukb2bids = {
 '25753_0': '{unrecogdir}/fMRI/sub-{subj}_{session}_task-rest_partial_correlation_matrix_d100',
 '25754_0': '{unrecogdir}/fMRI/sub-{subj}_{session}_task-rest_component_amplitudes_d25',
 '25755_0': '{unrecogdir}/fMRI/sub-{subj}_{session}_task-rest_component_amplitudes_d100',
+'20263_0': '{unrecogdir}/FreeSurfer',
 # raw
 'T1/T1': '{session}/anat/sub-{subj}_{session}_T1w',
 'dMRI/raw/AP': '{session}/dwi/sub-{subj}_{session}_acq-AP_dwi',


### PR DESCRIPTION
@mih - haven't studied the code, but this field is freesurfer recon and looks like this when currently unzipped.

```
./instance-2
./instance-2/FreeSurfer
./instance-2/FreeSurfer/stats
./instance-2/FreeSurfer/surf
./instance-2/FreeSurfer/label
./instance-2/FreeSurfer/mri
./instance-2/FreeSurfer/scripts
```
it would be nice if i could create the pattern.

`{subj}/ses-{instance}/Freesurfer/{subj}/{stats, surf, label, mri, scripts}`

this would allow setting the `SUBJECTS_DIR` to `{subj}/ses-{instance}/Freesurfer/`

i think this is the only field in my list amongst the imaging fields that's not in this mapping file.