### PR TITLE
Avoid leakage of absolute paths into the ukbfetch run record

### DIFF
--- a/datalad_ukbiobank/update.py
+++ b/datalad_ukbiobank/update.py
@@ -154,7 +154,9 @@ class Update(Interface):
         ds.run(
             cmd='ukbfetch -v -a{} -b.ukbbatch -o{}'.format(
                 quote_cmdlinearg(keyfile),
-                quote_cmdlinearg(str(tmpdir)),
+                # use relative path to tmpdir to avoid leakage
+                # of system-specific information into the run record
+                quote_cmdlinearg(str(tmpdir.relative_to(repo.pathobj))),
             ),
             explicit=True,
             outputs=['.'],


### PR DESCRIPTION
Run record is now

```
    {
     "chain": [],
     "cmd": "ukbfetch -v -a<keylocation> -b.ukbbatch -o.git/tmp/ukb",
     "dsid": "8635d33e-9e66-11ea-9f77-a0369f287950",
     "exit": 0,
     "extra_inputs": [],
     "inputs": [],
     "outputs": [
      "."
     ],
     "pwd": "."
    }

```
Key location is user input, hence we need not control that, but the output dir ist internally created, and no longer given with an absolute path
