### PR TITLE
Support interactive entry of UKB access key file location

### DIFF
--- a/datalad_ukbiobank/update.py
+++ b/datalad_ukbiobank/update.py
@@ -100,7 +100,12 @@ class Update(Interface):
         repo = ds.repo
         if not keyfile:
             # will error out, if no config was given
-            keyfile = repo.config.obtain('datalad.ukbiobank.keyfile')
+            keyfile = repo.config.obtain(
+                'datalad.ukbiobank.keyfile',
+                dialog_type='question',
+                title='Key file location',
+                text='Where is the location of the file with the UKB access key?',
+            )
 
         # prep for yield
         res = dict(


### PR DESCRIPTION
Otherwise it would just crash, when the option isn't given.