### PR TITLE
Maintain BIDS and native dataset layout in parallel

### DIFF
--- a/datalad_ukbiobank/init.py
+++ b/datalad_ukbiobank/init.py
@@ -47,10 +47,12 @@ class Init(Interface):
     After initialization the dataset will contain at least three branches:
 
     - incoming: to track the pristine ZIP files downloaded from UKB
-    - incoming-native: to track extracted ZIP file content, in a potentially
-      restructures layout (i.e. BIDS-like file name conventions)
-    - master: based off of incoming-native with potential manual modifications
-      applied
+    - incoming-native: to track individual files (some extracted from ZIP
+      files)
+    - incoming-bids: to track individual files in a layout where file name
+      conform to BIDS-conventions
+    - master: based off of incoming-native or incoming-bids (if enabled)
+      with potential manual modifications applied
     """
 
     _examples_ = [
@@ -58,6 +60,10 @@ class Init(Interface):
             text='Initialize a dataset in the current directory',
             code_cmd='datalad ukb-init 5874415 20227_2_0 20249_2_0',
             code_py='ukb_init(participant="5874415", records=["20227_2_0", "20249_2_0"])'),
+        dict(
+            text='Initialize a dataset in the current directory in BIDS layout',
+            code_cmd='datalad ukb-init --bids 5874415 20227_2_0',
+            code_py='ukb_init(participant="5874415", records=["20227_2_0"], bids=True)'),
     ]
 
     _params_ = dict(

--- a/datalad_ukbiobank/init.py
+++ b/datalad_ukbiobank/init.py
@@ -47,9 +47,9 @@ class Init(Interface):
     After initialization the dataset will contain at least three branches:
 
     - incoming: to track the pristine ZIP files downloaded from UKB
-    - incoming-processed: to track extracted ZIP file content, in a potentially
+    - incoming-native: to track extracted ZIP file content, in a potentially
       restructures layout (i.e. BIDS-like file name conventions)
-    - master: based off of incoming-processed with potential manual modifications
+    - master: based off of incoming-native with potential manual modifications
       applied
     """
 
@@ -148,7 +148,7 @@ class Init(Interface):
         )
         # establish rest of the branch structure: "incoming-processsed"
         # for extracted archive content
-        _add_incoming_branch('incoming-processed', branches, repo, batchfile)
+        _add_incoming_branch('incoming-native', branches, repo, batchfile)
         if bids:
             _add_incoming_branch('incoming-bids', branches, repo, batchfile)
         # force merge unrelated histories into master
@@ -161,7 +161,7 @@ class Init(Interface):
             'merge',
             '-m', 'Merge incoming',
             '--allow-unrelated-histories',
-            'incoming-bids' if bids else 'incoming-processed',
+            'incoming-bids' if bids else 'incoming-native',
         ])
 
         yield dict(

--- a/datalad_ukbiobank/tests/test_init.py
+++ b/datalad_ukbiobank/tests/test_init.py
@@ -16,12 +16,12 @@ def test_base(path):
     ds.ukb_init('12345', ['20249_2_0', '20249_3_0', '20250_2_0'])
     # standard branch setup
     eq_(sorted(ds.repo.get_branches()),
-        ['git-annex', 'incoming', 'incoming-processed', 'master'])
+        ['git-annex', 'incoming', 'incoming-native', 'master'])
     # standard batch file setup
     eq_(ds.repo.call_git(['cat-file', '-p', 'incoming:.ukbbatch']),
         '12345 20249_2_0\n12345 20249_3_0\n12345 20250_2_0\n')
     # intermediate branch is empty
-    eq_(ds.repo.call_git(['ls-tree', 'incoming-processed']), '')
+    eq_(ds.repo.call_git(['ls-tree', 'incoming-native']), '')
     # no batch in master
     assert_not_in('ukbbatch', ds.repo.call_git(['ls-tree', 'master']))
 
@@ -42,10 +42,10 @@ def test_bids(path):
                 bids=True)
     # standard branch setup
     eq_(sorted(ds.repo.get_branches()),
-        ['git-annex', 'incoming', 'incoming-bids', 'incoming-processed',
+        ['git-annex', 'incoming', 'incoming-bids', 'incoming-native',
          'master'])
     # intermediate branches are empty
-    for b in 'incoming-bids', 'incoming-processed':
+    for b in 'incoming-bids', 'incoming-native':
         eq_(ds.repo.call_git(['ls-tree', b]), '')
     # no batch in master
     assert_not_in('ukbbatch', ds.repo.call_git(['ls-tree', 'master']))
@@ -53,5 +53,5 @@ def test_bids(path):
     # smoke test for a reinit
     ds.ukb_init('12345', ['20250_2_0'], bids=True, force=True)
     eq_(sorted(ds.repo.get_branches()),
-        ['git-annex', 'incoming', 'incoming-bids', 'incoming-processed',
+        ['git-annex', 'incoming', 'incoming-bids', 'incoming-native',
          'master'])

--- a/datalad_ukbiobank/tests/test_init.py
+++ b/datalad_ukbiobank/tests/test_init.py
@@ -11,7 +11,7 @@ from datalad.tests.utils import (
 
 
 @with_tempfile
-def test_dummy(path):
+def test_base(path):
     ds = create(path)
     ds.ukb_init('12345', ['20249_2_0', '20249_3_0', '20250_2_0'])
     # standard branch setup
@@ -33,3 +33,25 @@ def test_dummy(path):
     ds.ukb_init('12345', ['20250_2_0'], force=True)
     eq_(ds.repo.call_git(['cat-file', '-p', 'incoming:.ukbbatch']),
         '12345 20250_2_0\n')
+
+
+@with_tempfile
+def test_bids(path):
+    ds = create(path)
+    ds.ukb_init('12345', ['20249_2_0', '20249_3_0', '20250_2_0'],
+                bids=True)
+    # standard branch setup
+    eq_(sorted(ds.repo.get_branches()),
+        ['git-annex', 'incoming', 'incoming-bids', 'incoming-processed',
+         'master'])
+    # intermediate branches are empty
+    for b in 'incoming-bids', 'incoming-processed':
+        eq_(ds.repo.call_git(['ls-tree', b]), '')
+    # no batch in master
+    assert_not_in('ukbbatch', ds.repo.call_git(['ls-tree', 'master']))
+
+    # smoke test for a reinit
+    ds.ukb_init('12345', ['20250_2_0'], bids=True, force=True)
+    eq_(sorted(ds.repo.get_branches()),
+        ['git-annex', 'incoming', 'incoming-bids', 'incoming-processed',
+         'master'])

--- a/datalad_ukbiobank/tests/test_update.py
+++ b/datalad_ukbiobank/tests/test_update.py
@@ -143,7 +143,7 @@ def test_bids(dspath, records):
     with patch.dict('os.environ', {'PATH': '{}:{}'.format(
             str(bin_dir),
             os.environ['PATH'])}):
-        ds.ukb_update(merge=True)
+        ds.ukb_update(merge=True, force_update=True)
 
     bids_files = ds.repo.get_files('incoming-bids')
     master_files = ds.repo.get_files()

--- a/datalad_ukbiobank/tests/test_update.py
+++ b/datalad_ukbiobank/tests/test_update.py
@@ -82,7 +82,7 @@ def test_base(dspath, records):
 
     # get expected file layout
     incoming = ds.repo.get_files('incoming')
-    incoming_p = ds.repo.get_files('incoming-processed')
+    incoming_p = ds.repo.get_files('incoming-native')
     for i in ['12345_25748_2_0.txt', '12345_25748_3_0.txt', '12345_20227_2_0.zip']:
         assert_in(i, incoming)
     for i in ['25748_2_0.txt', '25748_3_0.txt', '20227_2_0/fMRI/rfMRI.nii.gz']:

--- a/datalad_ukbiobank/tests/test_update.py
+++ b/datalad_ukbiobank/tests/test_update.py
@@ -153,3 +153,11 @@ def test_bids(dspath, records):
             'ses-3/non-bids/fMRI/sub-12345_ses-3_task-hariri_eprime.txt']:
         assert_in(i, bids_files)
         assert_in(i, master_files)
+
+    # now re-init with a different record subset and rerun
+    ds.ukb_init('12345', ['25747_2_0.adv', '25748_2_0', '25748_3_0'],
+                bids=True, force=True)
+    with patch.dict('os.environ', {'PATH': '{}:{}'.format(
+            str(bin_dir),
+            os.environ['PATH'])}):
+        ds.ukb_update(merge=True, force_update=True)

--- a/datalad_ukbiobank/tests/test_update.py
+++ b/datalad_ukbiobank/tests/test_update.py
@@ -34,9 +34,24 @@ for line in open('.ukbbatch'):
 """
 
 
+def make_ukbfetch(ds, records):
+    # fake ukbfetch
+    bin_dir = ds.pathobj / '.git' / 'tmp'
+    bin_dir.mkdir()
+    ukbfetch_file = bin_dir / 'ukbfetch'
+    ukbfetch_file.write_text(
+        ukbfetch_code.format(
+            pythonexec=sys.executable,
+            basepath=records,
+        )
+    )
+    ukbfetch_file.chmod(0o744)
+    return bin_dir
+
+
 @with_tempfile
 @with_tempfile(mkdir=True)
-def test_dummy(dspath, records):
+def test_base(dspath, records):
     # make fake UKB datarecord downloads
     make_datarecord_zips('12345', records)
 
@@ -49,16 +64,7 @@ def test_dummy(dspath, records):
     ds.config.add('datalad.ukbiobank.keyfile', 'dummy', where='local')
 
     # fake ukbfetch
-    bin_dir = ds.pathobj / '.git' / 'tmp'
-    bin_dir.mkdir()
-    ukbfetch_file = bin_dir / 'ukbfetch'
-    ukbfetch_file.write_text(
-        ukbfetch_code.format(
-            pythonexec=sys.executable,
-            basepath=records,
-        )
-    )
-    ukbfetch_file.chmod(0o744)
+    bin_dir = make_ukbfetch(ds, records)
 
     # refuse to operate on dirty datasets
     (ds.pathobj / 'dirt').write_text('dust')
@@ -100,3 +106,50 @@ def test_dummy(dspath, records):
             ds.ukb_update(merge=True, force_update=True, on_failure='ignore'),
             status='impossible',
             message='Refuse to merge into incoming* branch',)
+
+
+@with_tempfile
+@with_tempfile(mkdir=True)
+def test_bids(dspath, records):
+    # make fake UKB datarecord downloads
+    make_datarecord_zips('12345', records)
+
+    # init dataset
+    ds = create(dspath)
+    ds.ukb_init(
+        '12345',
+        ['20227_2_0', '25747_2_0.adv', '25748_2_0', '25748_3_0'],
+        bids=True)
+    # dummy key file, no needed to bypass tests
+    ds.config.add('datalad.ukbiobank.keyfile', 'dummy', where='local')
+    bin_dir = make_ukbfetch(ds, records)
+
+    # put fake ukbfetch in the path and run
+    with patch.dict('os.environ', {'PATH': '{}:{}'.format(
+            str(bin_dir),
+            os.environ['PATH'])}):
+        ds.ukb_update(merge=True)
+
+    bids_files = ds.repo.get_files('incoming-bids')
+    master_files = ds.repo.get_files()
+    for i in [
+            'ses-2/func/sub-12345_ses-2_task-rest_bold.nii.gz',
+            'ses-2/non-bids/fMRI/sub-12345_ses-2_task-hariri_eprime.txt',
+            'ses-3/non-bids/fMRI/sub-12345_ses-3_task-hariri_eprime.txt']:
+        assert_in(i, bids_files)
+        assert_in(i, master_files)
+
+    # run again, nothing bad happens
+    with patch.dict('os.environ', {'PATH': '{}:{}'.format(
+            str(bin_dir),
+            os.environ['PATH'])}):
+        ds.ukb_update(merge=True)
+
+    bids_files = ds.repo.get_files('incoming-bids')
+    master_files = ds.repo.get_files()
+    for i in [
+            'ses-2/func/sub-12345_ses-2_task-rest_bold.nii.gz',
+            'ses-2/non-bids/fMRI/sub-12345_ses-2_task-hariri_eprime.txt',
+            'ses-3/non-bids/fMRI/sub-12345_ses-3_task-hariri_eprime.txt']:
+        assert_in(i, bids_files)
+        assert_in(i, master_files)

--- a/datalad_ukbiobank/ukb2bids.py
+++ b/datalad_ukbiobank/ukb2bids.py
@@ -50,11 +50,12 @@ def restructure_ukb2bids(ds, subid, unrecognized_dir, base_path=None):
             lgr.debug('Skip mapping %s, no longer exists (likely moved before)', path)
             continue
         rp_parts = list(Path(fp['path']).relative_to(base_path or ds.pathobj).parts)
-        if rp_parts[0].startswith(('.git', '.datalad')):
-            # ignore internal data structures
-            continue
         # instance number will serve as BIDS session
-        session = rp_parts[0].split('_')[1]
+        try:
+            session = rp_parts[0].split('_')[1]
+        except IndexError:
+            # ignore anything that doesn't look like a UKB data record
+            continue
         # pull out instance number from the top-level component, because the matching
         # is uniform and agnostic of instances
         rp_parts[0] = '_'.join(rp_parts[0].split('_')[::2])
@@ -104,16 +105,11 @@ def restructure_ukb2bids(ds, subid, unrecognized_dir, base_path=None):
         full_sourcepath = Path(fp['path'])
         full_targetpath = ds.pathobj / target_path
         if full_targetpath.exists():
-            yield dict(
-                res,
-                path=fp['path'],
-                status='error',
-                message=('Target path %s already exists (naming conflict?)',
-                         target_path)
-            )
-            continue
-        # ensure target directory
-        full_targetpath.parent.mkdir(parents=True, exist_ok=True)
+            lgr.info('Overwriting %s', str(target_path))
+            target_path.unlink()
+        else:
+            # ensure target directory
+            full_targetpath.parent.mkdir(parents=True, exist_ok=True)
         full_sourcepath.rename(full_targetpath)
         # delete empty source directories
         for p in full_sourcepath.parents:

--- a/datalad_ukbiobank/ukb2bids.py
+++ b/datalad_ukbiobank/ukb2bids.py
@@ -40,7 +40,7 @@ def restructure_ukb2bids(ds, subid, unrecognized_dir, base_path=None):
     for fp in ds.status(
             path=base_path,
             annex=None,
-            untracked='no',
+            untracked='all',
             eval_subdataset_state='no',
             report_filetype='raw',
             return_type='generator',

--- a/datalad_ukbiobank/update.py
+++ b/datalad_ukbiobank/update.py
@@ -242,7 +242,8 @@ class Update(Interface):
             # unstage change to present a later `datalad save` a single
             # changeset to be saved (otherwise it might try to keep staged
             # content staged und only save additional modifications)
-            repo.call_git(['restore', '--staged', '.'])
+            #repo.call_git(['restore', '--staged', '.'])
+            repo.call_git(['reset', 'HEAD', '.'])
 
             # and now do the BIDSification
             from datalad_ukbiobank.ukb2bids import restructure_ukb2bids

--- a/datalad_ukbiobank/update.py
+++ b/datalad_ukbiobank/update.py
@@ -232,9 +232,6 @@ class Update(Interface):
             repo.call_git(['checkout', 'incoming-bids'])
             # we do not support any external modifications of this
             # incoming-bids branch
-            # first wipe all previously existing content
-            for fp in repo.get_files():
-                (repo.pathobj / fp).unlink()
             # blindly take over whatever is in incoming-processed
             repo.call_git([
                 'merge', 'incoming-processed',

--- a/datalad_ukbiobank/update.py
+++ b/datalad_ukbiobank/update.py
@@ -71,13 +71,13 @@ class Update(Interface):
             action='store_true',
             doc="""merge any updates into the active branch. If a BIDS layout
             is maintained in the dataset (incoming-bids branch) it will be
-            merged into the active branch, the incoming-processed branch
+            merged into the active branch, the incoming-native branch
             otherwise.
             """),
         force_update=Parameter(
             args=('--force-update',),
             action='store_true',
-            doc="""update the incoming-processed branch, even if (re-)download
+            doc="""update the incoming-native branch, even if (re-)download
             did not yield changed content (can be useful when restructuring
             setup has changed)."""),
     )
@@ -172,14 +172,14 @@ class Update(Interface):
             return
 
         # onto extraction and transformation of downloaded content
-        repo.call_git(['checkout', 'incoming-processed'])
+        repo.call_git(['checkout', 'incoming-native'])
 
         # mark the incoming change as merged
         # (but we do not actually want any branch content)
         repo.call_git(['merge', 'incoming', '--strategy=ours'])
 
         for fp in repo.get_content_info(
-                ref='incoming-processed',
+                ref='incoming-native',
                 eval_file_type=False):
             fp.unlink()
 
@@ -235,10 +235,10 @@ class Update(Interface):
             # (but we do not actually want any branch content)
             repo.call_git(['merge', 'incoming', '--strategy=ours'])
             # prepare the worktree to match the latest state
-            # of incoming-processed but keep histories separate
+            # of incoming-native but keep histories separate
             # (ie. no merge), because we cannot handle partial
             # changes
-            repo.call_git(['read-tree', '-u', '--reset', 'incoming-processed'])
+            repo.call_git(['read-tree', '-u', '--reset', 'incoming-native'])
             # unstage change to present a later `datalad save` a single
             # changeset to be saved (otherwise it might try to keep staged
             # content staged und only save additional modifications)
@@ -266,7 +266,7 @@ class Update(Interface):
         repo.call_git(['checkout', initial_branch])
 
         if initial_branch in ('incoming',
-                              'incoming-processed',
+                              'incoming-native',
                               'incoming-bids'):
             yield dict(
                 res,
@@ -279,7 +279,7 @@ class Update(Interface):
         repo.call_git([
             'merge',
             '-m', "Merge update from UKbiobank",
-            'incoming-bids' if want_bids else 'incoming-processed'])
+            'incoming-bids' if want_bids else 'incoming-native'])
 
         yield dict(
             res,


### PR DESCRIPTION
The decision whether a BIDS representation is desired, is now made via
`init`. This seems to make more sense than having to indicate that
for each call to `update`.

The ability to customize the naming of a directory for all unrecognized
content in the BIDS layout has been removed. I consider that a needless
complication with the switch to multiple branches.

Test are expanded to cover layout differences.

Fixes gh-38

TODO:
- [x] forced update wipes out content of bids branch

@satra please have a look, if this works for you. Thx!