### PR TITLE
ukb-update --drop {extracted|archives}

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
 [options]
 python_requires = >= 3.5
 install_requires =
-    datalad >= 0.12.2
+    datalad >= 0.13rc2
 test_requires =
     nose
     coverage


### PR DESCRIPTION
Add ability to avoid storage duplication by either drop downloaded
archives or extracted archive content. In both cases single file access
in any branch layout (except in 'incoming' itself when dropping
downloaded archives) remains unimpaired).

Fixes gh-44