### PR TITLE
RF: _run_annex_* is deprecated in datalad core

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -146,6 +146,8 @@ install:
 
 build_script:
   - pip install -r requirements-devel.txt
+  # in anticipation of datalad 0.14 release test against master:
+  - pip install git+https://github.com/datalad/datalad.git@master
   - pip install "."
 
 

--- a/datalad_ukbiobank/update.py
+++ b/datalad_ukbiobank/update.py
@@ -279,24 +279,14 @@ class Update(Interface):
 
         if drop:
             if drop == 'archives':
-                drop_kwargs = dict(
-                    # we need to force the drop, because the download is the
-                    # only copy we have in general
-                    opts=['--force', '--branch', 'incoming', '-I', '*.zip'],
-                    expect_fail=False,
-                    expect_stderr=False,
-                    runner="gitwitless",
-                )
+                # we need to force the drop, because the download is the
+                # only copy we have in general
+                drop_opts = ['--force', '--branch', 'incoming', '-I', '*.zip']
             else:  # drop == 'extracted':
-                drop_kwargs = dict(
-                    opts=['--in', 'datalad-archives',
-                          '--branch', 'incoming-native'],
-                    expect_fail=False,
-                    expect_stderr=False,
-                    runner="gitwitless",
-                )
+                drop_opts=['--in', 'datalad-archives',
+                           '--branch', 'incoming-native']
 
-            for rec in repo._run_annex_command_json('drop', **drop_kwargs):
+            for rec in repo.call_annex_records(['drop'] + drop_opts):
                 if not rec.get('success', False):
                     yield dict(
                         action='drop',

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
 [options]
 python_requires = >= 3.5
 install_requires =
-    datalad >= 0.13rc2
+    datalad >= 0.13.7
 test_requires =
     nose
     coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
 [options]
 python_requires = >= 3.5
 install_requires =
+    # really is a dependency on the to-be-released 0.14
     datalad >= 0.13.7
 test_requires =
     nose


### PR DESCRIPTION
Remove calls that are deprecated in datalad core.
Sits on top of PR #59

Closes #58 (hopefully)