### PR TITLE
Fix update --drop extracted crash (missing archives SR)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,9 @@
 
 
 # make repository clone cheap
-shallow_clone: true
+# nope, versioneer cannot handle it (yet)
+# https://github.com/python-versioneer/python-versioneer/issues/252
+shallow_clone: false
 
 
 environment:


### PR DESCRIPTION
We now check whether there is a `datalad-archives` special remote,
before attempting to drop from it. We could have used an approach
that check if there is candidate content for this SR, but that would
likely duplicate logic and be more fragile wrt future changes.

Here we test for the error/crash condition directly.

Debugged with @loj

Closes #69