### PR TITLE
CI: Enable new codecov uploader in Appveyor CI, fixes #77

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,6 +64,7 @@ environment:
       DTS: datalad_ukbiobank
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       INSTALL_SYSPKGS: python3-virtualenv
+      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20201228T023115Z/pool/main/g/git-annex/git-annex_8.20201127-1_amd64.deb
       # system git-annex is way too old, use better one
     # Windows core tests
@@ -80,6 +81,7 @@ environment:
       PY: 3.8
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
+      CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
 
 
 # it is OK to specify paths that may not exist for a particular test run
@@ -177,15 +179,12 @@ test_script:
 
 
 after_test:
-  # move coverage into the project dir to make default handling applicable
-  - cmd: move .coverage ..
-  - sh: mv .coverage ..
-  - cd ..
-  # use windows codecov uploader package
-  - cmd: choco install codecov
-  - cmd: python -m coverage xml
-  - cmd: codecov -f coverage.xml
-  - sh: bash <(curl -sfS https://codecov.io/bash)
+  - python -m coverage xml
+  - cmd: curl -fsSL -o codecov.exe "https://uploader.codecov.io/latest/windows/codecov.exe"
+  - cmd: .\codecov.exe -f "coverage.xml"
+  - sh: "curl -Os $CODECOV_BINARY"
+  - sh: chmod +x codecov
+  - sh: ./codecov
 
 
 #on_success:


### PR DESCRIPTION
This mirrors the approach in https://github.com/datalad/datalad-osf/pull/153. It replaces the use of the choco package because they haven't updated to the new version. Its still some time until the bash uploader is fully sunset, so we could also wait if https://community.chocolatey.org/packages/codecov get updated in time.