### PR TITLE
MNT: Remove eval_file_type (removed from core) from code base

### DIFF
--- a/datalad_ukbiobank/update.py
+++ b/datalad_ukbiobank/update.py
@@ -197,8 +197,7 @@ class Update(Interface):
         repo.call_git(['merge', 'incoming', '--strategy=ours'])
 
         for fp in repo.get_content_info(
-                ref='incoming-native',
-                eval_file_type=False):
+			ref='incoming-native'):
             if fp.name.startswith('.git') \
                     or fp.name.startswith('.datalad') \
                     or fp.name.startswith('.ukb'):


### PR DESCRIPTION
https://github.com/datalad/datalad/pull/6738 removed the deprecated and almost unused internal `eval_file_type` parameter. This companion PR removes the (effectless) use of this parameter from ``datalad-ukbiobank`` (a change I regard as needed to interoperate with 0.16.4 and higher, but backwards compatible).