### PR TITLE
Switch to pytest, and bump dependency on Python (3.7) and datalad (0.17)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20201228T023115Z/pool/main/g/git-annex/git-annex_8.20201127-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m snapshot
       # system git-annex is way too old, use better one
     # Windows core tests
     - ID: WinP38
@@ -148,7 +148,11 @@ install:
   # Install git-annex on windows, otherwise INSTALL_SYSPKGS can be used
   # deploy git-annex, if desired
   - cmd: IF DEFINED INSTALL_GITANNEX datalad-installer --sudo ok %INSTALL_GITANNEX%
-  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer --sudo ok ${INSTALL_GITANNEX}"
+  # in case of a snapshot installation, use the following approach to adjust
+  # the PATH as necessary
+  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok ${INSTALL_GITANNEX}"
+  # add location of datalad installer results to PATH
+  - sh: "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
 
 
 #before_build:
@@ -156,8 +160,8 @@ install:
 
 
 build_script:
-  - pip install -r requirements-devel.txt
-  - pip install "."
+  - python -m pip install -r requirements-devel.txt
+  - python -m pip install .
 
 
 #after_build:
@@ -173,9 +177,8 @@ test_script:
   - cmd: md __testhome__
   - sh: mkdir __testhome__
   - cd __testhome__
-    # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
-  - cmd: python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_ukbiobank %DTS%
-  - sh:  python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_ukbiobank ${DTS}
+  - cmd: python -m pytest -s -v -m "not (turtle)" --cov=datalad_ukbiobank --pyargs %DTS%
+  - sh:  python -m pytest -s -v -m "not (turtle)" --cov=datalad_ukbiobank --pyargs ${DTS}
 
 
 after_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-      INSTALL_GITANNEX: git-annex -m snapshot
+      INSTALL_GITANNEX: git-annex=10.20220525 -m datalad/git-annex:release
       # system git-annex is way too old, use better one
     # Windows core tests
     - ID: WinP38
@@ -73,13 +73,13 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       # Python version specification is non-standard on windows
       PY: 38-x64
-      INSTALL_GITANNEX: git-annex -m datalad/packages
+      INSTALL_GITANNEX: git-annex=10.20220525 -m datalad/git-annex:release
     # MacOS core tests
     - ID: MacP38
       DTS: datalad_ukbiobank
       APPVEYOR_BUILD_WORKER_IMAGE: macOS
       PY: 3.8
-      INSTALL_GITANNEX: git-annex
+      INSTALL_GITANNEX: git-annex=10.20220525 -m datalad/git-annex:release
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
 

--- a/datalad_ukbiobank/__init__.py
+++ b/datalad_ukbiobank/__init__.py
@@ -19,8 +19,3 @@ command_suite = (
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
-
-
-# adopt standard datalad test setup
-from datalad import setup_package
-from datalad import teardown_package

--- a/datalad_ukbiobank/conftest.py
+++ b/datalad_ukbiobank/conftest.py
@@ -1,0 +1,16 @@
+try:
+    from datalad.conftest import setup_package
+except ImportError:
+    # assume old datalad without pytest support introduced in
+    # https://github.com/datalad/datalad/pull/6273
+    import pytest
+    from datalad import setup_package as _setup_package
+    from datalad import teardown_package as _teardown_package
+
+
+    @pytest.fixture(autouse=True, scope="session")
+    def setup_package():
+        _setup_package()
+        yield
+        _teardown_package()
+

--- a/datalad_ukbiobank/tests/__init__.py
+++ b/datalad_ukbiobank/tests/__init__.py
@@ -1,8 +1,5 @@
 from zipfile import ZipFile
 
-from datalad.tests.utils import (
-    with_tempfile,
-)
 from datalad.utils import Path
 
 

--- a/datalad_ukbiobank/tests/test_init.py
+++ b/datalad_ukbiobank/tests/test_init.py
@@ -2,7 +2,7 @@ from datalad.api import (
     create,
     ukb_init,
 )
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_not_in,
     assert_status,
     assert_true,
@@ -13,7 +13,7 @@ from datalad.tests.utils import (
 
 
 @with_tempfile
-def test_base(path):
+def test_base(path=None):
     ds = create(path)
     ds.ukb_init('12345', ['20249_2_0', '20249_3_0', '20250_2_0'])
     # standard branch setup
@@ -43,7 +43,7 @@ def test_base(path):
 
 
 @with_tempfile
-def test_bids(path):
+def test_bids(path=None):
     ds = create(path)
     ds.ukb_init('12345', ['20249_2_0', '20249_3_0', '20250_2_0'],
                 bids=True)

--- a/datalad_ukbiobank/tests/test_update.py
+++ b/datalad_ukbiobank/tests/test_update.py
@@ -6,7 +6,7 @@ from datalad.api import (
     create,
     clone,
 )
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_in,
     assert_in_results,
     assert_not_in,
@@ -57,7 +57,7 @@ def make_ukbfetch(ds, records):
 @with_tempfile
 @with_tempfile(mkdir=True)
 @with_tempfile(mkdir=True)
-def test_base(dspath, records, clonedir):
+def test_base(dspath=None, records=None, clonedir=None):
     # make fake UKB datarecord downloads
     make_datarecord_zips('12345', records)
 
@@ -124,7 +124,7 @@ def test_base(dspath, records, clonedir):
 @skip_if_on_windows  # see gh-61
 @with_tempfile
 @with_tempfile(mkdir=True)
-def test_bids(dspath, records):
+def test_bids(dspath=None, records=None):
     # make fake UKB datarecord downloads
     make_datarecord_zips('12345', records)
 
@@ -180,7 +180,7 @@ def test_bids(dspath, records):
 @skip_if_on_windows  # see gh-61
 @with_tempfile
 @with_tempfile(mkdir=True)
-def test_drop(dspath, records):
+def test_drop(dspath=None, records=None):
     make_datarecord_zips('12345', records)
     ds = create(dspath)
     ds.ukb_init(

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,6 +1,4 @@
 # requirements for a development environment
-nose
-coverage
+-e .[devel]
 sphinx
 sphinx_rtd_theme
-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,15 +12,18 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 install_requires =
-    datalad >= 0.14.0rc1
-    pytest
-test_requires =
-    nose
-    coverage
+    datalad >= 0.17.0
 packages = find:
 include_package_data = True
+
+[options.extras_require]
+# this matches the name used by -core and what is expected by some CI setups
+devel =
+    pytest
+    pytest-cov
+    coverage
 
 [options.packages.find]
 exclude=


### PR DESCRIPTION
TODO

- [x] The extension or one test is broken with git-annex 10.20220526-gc6b112108 (linux) and 10.20220624 (brew) -- last known-to-work version is 10.20220504 https://github.com/datalad/datalad-ukbiobank/issues/89