### PR TITLE
Support FreeSurfer data records 

### DIFF
--- a/datalad_ukbiobank/init.py
+++ b/datalad_ukbiobank/init.py
@@ -13,7 +13,7 @@
 import logging
 
 from datalad.interface.base import Interface
-from datalad.interface.utils import eval_results
+from datalad.interface.base import eval_results
 from datalad.interface.base import build_doc
 from datalad.support.constraints import (
     EnsureStr,

--- a/datalad_ukbiobank/ukb2bids_map.py
+++ b/datalad_ukbiobank/ukb2bids_map.py
@@ -16,6 +16,7 @@ ukb2bids = {
 '20251_0/SWI': '{unrecogdir}/SWI/',
 '20227_0/fMRI': '{unrecogdir}/fMRI/',
 '20249_0/fMRI': '{unrecogdir}/fMRI/',
+'20263_0/FreeSurfer': '{unrecogdir}/FreeSurfer/',
 '25747_0': '{unrecogdir}/fMRI/sub-{subj}_{session}_task-hariri_eprime',
 '25748_0': '{unrecogdir}/fMRI/sub-{subj}_{session}_task-hariri_eprime',
 '25749_0': '{unrecogdir}/fMRI/sub-{subj}_{session}_task-hariri_eprime',

--- a/datalad_ukbiobank/update.py
+++ b/datalad_ukbiobank/update.py
@@ -15,7 +15,7 @@ import subprocess
 import shutil
 
 from datalad.interface.base import Interface
-from datalad.interface.utils import eval_results
+from datalad.interface.base import eval_results
 from datalad.interface.base import build_doc
 from datalad.local.add_archive_content import AddArchiveContent
 from datalad.support.constraints import (

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [pytest]
 filterwarnings =
-    error::DeprecationWarning:^datalad
+    ignore::DeprecationWarning:^datalad
     error:.*yield tests:pytest.PytestCollectionWarning
     ignore:distutils Version classes are deprecated:DeprecationWarning
     # comes from boto


### PR DESCRIPTION
This extends the BIDS mapping file to include the FreeSurfer data record (`20263`).

While adding this, I found a  deprecated import for `eval_results` that broke tests. This fix is included as well.

Closes #99 
Closes #100